### PR TITLE
BBL-440 | updating slack ci notif template

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,11 +93,6 @@ jobs:
       - slack/notify:
           event: fail
           mentions: '@leverage-support'
-          template: basic_fail_1
-          channel: 'tools-ci'
-      - slack/notify:
-          event: pass
-          #template: success_tagged_deploy_1
           custom: |
             {
               "blocks": [
@@ -105,7 +100,7 @@ jobs:
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": "Successful Pipeline! :heavy_check_mark: :checkered_flag: :video-games-star: :video-games-mario-luigi-dance: :bb-leverage::heart: :open-source: :tada:",
+                    "text": "Failed Pipeline! :negative_squared_cross_mark::rotating_light::fire::bash-fire::bangbang::video-games-doom-mad::stopp:",
                     "emoji": true
                   }
                 },
@@ -114,6 +109,40 @@ jobs:
                   "text": {
                     "type": "mrkdwn",
                     "text": "*Project*: $CIRCLE_PROJECT_REPONAME \n *User*: $CIRCLE_USERNAME \n *Job*: $CIRCLE_JOB in *repo* $CIRCLE_PROJECT_REPONAME \n *Branch:* $CIRCLE_BRANCH \n *PR:* $CIRCLE_PULL_REQUEST \n *Last Commit:* $CIRCLE_SHA1"
+                  },
+                  "accessory": {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": ":arrow_forward: View Job in CircleCi",
+                      "emoji": true
+                    },
+                    "value": "click_me_123",
+                    "url": "$CIRCLE_BUILD_URL",
+                    "action_id": "button-action"
+                  }
+                }
+              ]
+            }
+          channel: 'tools-ci'
+      - slack/notify:
+          event: pass
+          custom: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "Successful Pipeline! :heavy_check_mark::checkered_flag::video-games-star::video-games-mario-luigi-dance: :tada:   :bb-leverage::heart::open-source:",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":heavy_check_mark: *Project*: $CIRCLE_PROJECT_REPONAME \n :heavy_check_mark: *User*: $CIRCLE_USERNAME \n :heavy_check_mark: *Job*: $CIRCLE_JOB in *repo* $CIRCLE_PROJECT_REPONAME \n :heavy_check_mark: *Branch:* $CIRCLE_BRANCH \n :heavy_check_mark: *PR:* $CIRCLE_PULL_REQUEST \n :heavy_check_mark: *Last Commit:* $CIRCLE_SHA1"
                   },
                   "accessory": {
                     "type": "button",
@@ -176,11 +205,6 @@ jobs:
       - slack/notify:
           event: fail
           mentions: '@leverage-support'
-          template: basic_fail_1
-          channel: 'tools-ci'
-      - slack/notify:
-          event: pass
-          #template: success_tagged_deploy_1
           custom: |
             {
               "blocks": [
@@ -188,7 +212,7 @@ jobs:
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": "Successful Pipeline! :heavy_check_mark: :checkered_flag: :video-games-star: :video-games-mario-luigi-dance: :bb-leverage::heart: :open-source: :tada:",
+                    "text": "Failed Pipeline! :negative_squared_cross_mark::rotating_light::fire::bash-fire::bangbang::video-games-doom-mad::stopp:",
                     "emoji": true
                   }
                 },
@@ -197,6 +221,40 @@ jobs:
                   "text": {
                     "type": "mrkdwn",
                     "text": "*Project*: $CIRCLE_PROJECT_REPONAME \n *User*: $CIRCLE_USERNAME \n *Job*: $CIRCLE_JOB in *repo* $CIRCLE_PROJECT_REPONAME \n *Branch:* $CIRCLE_BRANCH \n *PR:* $CIRCLE_PULL_REQUEST \n *Last Commit:* $CIRCLE_SHA1"
+                  },
+                  "accessory": {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": ":arrow_forward: View Job in CircleCi",
+                      "emoji": true
+                    },
+                    "value": "click_me_123",
+                    "url": "$CIRCLE_BUILD_URL",
+                    "action_id": "button-action"
+                  }
+                }
+              ]
+            }
+          channel: 'tools-ci'
+      - slack/notify:
+          event: pass
+          custom: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "Successful Pipeline! :heavy_check_mark::checkered_flag::video-games-star::video-games-mario-luigi-dance: :tada:   :bb-leverage::heart::open-source:",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":heavy_check_mark: *Project*: $CIRCLE_PROJECT_REPONAME \n :heavy_check_mark: *User*: $CIRCLE_USERNAME \n :heavy_check_mark: *Job*: $CIRCLE_JOB in *repo* $CIRCLE_PROJECT_REPONAME \n :heavy_check_mark: *Branch:* $CIRCLE_BRANCH \n :heavy_check_mark: *PR:* $CIRCLE_PULL_REQUEST \n :heavy_check_mark: *Last Commit:* $CIRCLE_SHA1"
                   },
                   "accessory": {
                     "type": "button",

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,13 +113,13 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Project*: $CIRCLE_PROJECT_REPONAME \\n *User*: $CIRCLE_PR_USERNAME \\n *Job*: ($CIRCLE_JOB) in *repo* $CIRCLE_PROJECT_REPONAME ($CIRCLE_BRANCH | $CIRCLE_PULL_REQUEST | $CIRCLE_SHA1)"
+                    "text": "*Project*: $CIRCLE_PROJECT_REPONAME \n *User*: $CIRCLE_PR_USERNAME \n *Job*: ($CIRCLE_JOB) in *repo* $CIRCLE_PROJECT_REPONAME \n *branch* $CIRCLE_BRANCH | *pr* $CIRCLE_PULL_REQUEST | *last commit* $CIRCLE_SHA1)"
                   },
                   "accessory": {
                     "type": "button",
                     "text": {
                       "type": "plain_text",
-                      "text": ":arrow_forward: View Job",
+                      "text": ":arrow_forward: View Job in CircleCi",
                       "emoji": true
                     },
                     "value": "click_me_123",
@@ -196,13 +196,13 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Project*: $CIRCLE_PROJECT_REPONAME \\n *User*: $CIRCLE_PR_USERNAME \\n *Job*: ($CIRCLE_JOB) in *repo* $CIRCLE_PROJECT_REPONAME ($CIRCLE_BRANCH | $CIRCLE_PULL_REQUEST | $CIRCLE_SHA1)"
+                    "text": "*Project*: $CIRCLE_PROJECT_REPONAME \n *User*: $CIRCLE_PR_USERNAME \n *Job*: ($CIRCLE_JOB) in *repo* $CIRCLE_PROJECT_REPONAME \n *branch* $CIRCLE_BRANCH | *pr* $CIRCLE_PULL_REQUEST | *last commit* $CIRCLE_SHA1)"
                   },
                   "accessory": {
                     "type": "button",
                     "text": {
                       "type": "plain_text",
-                      "text": ":arrow_forward: View Job",
+                      "text": ":arrow_forward: View Job in CircleCi",
                       "emoji": true
                     },
                     "value": "click_me_123",

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Project*: $CIRCLE_PROJECT_REPONAME \n *User*: $CIRCLE_PR_USERNAME \n *Job*: ($CIRCLE_JOB) in *repo* $CIRCLE_PROJECT_REPONAME \n *branch* $CIRCLE_BRANCH | *pr* $CIRCLE_PULL_REQUEST | *last commit* $CIRCLE_SHA1)"
+                    "text": "*Project*: $CIRCLE_PROJECT_REPONAME \n *User*: CIRCLE_PROJECT_USERNAME \n *Job*: ($CIRCLE_JOB) in *repo* $CIRCLE_PROJECT_REPONAME \n *branch* $CIRCLE_BRANCH | *pr* $CIRCLE_PULL_REQUEST | *last commit* $CIRCLE_SHA1)"
                   },
                   "accessory": {
                     "type": "button",
@@ -196,7 +196,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Project*: $CIRCLE_PROJECT_REPONAME \n *User*: $CIRCLE_PR_USERNAME \n *Job*: ($CIRCLE_JOB) in *repo* $CIRCLE_PROJECT_REPONAME \n *branch* $CIRCLE_BRANCH | *pr* $CIRCLE_PULL_REQUEST | *last commit* $CIRCLE_SHA1)"
+                    "text": "*Project*: $CIRCLE_PROJECT_REPONAME \n *User*: CIRCLE_PROJECT_USERNAME \n *Job*: ($CIRCLE_JOB) in *repo* $CIRCLE_PROJECT_REPONAME \n *branch* $CIRCLE_BRANCH | *pr* $CIRCLE_PULL_REQUEST | *last commit* $CIRCLE_SHA1)"
                   },
                   "accessory": {
                     "type": "button",

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": "Successful Pipeline! :heavy_check_mark: :checkered_flag: :tada:",
+                    "text": "Successful Pipeline! :heavy_check_mark: :checkered_flag: :video-games-star: :tada:",
                     "emoji": true
                   }
                 },
@@ -113,7 +113,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Project*: $CIRCLE_PROJECT_REPONAME \n *User*: $CIRCLE_USERNAME \n *Job*: $CIRCLE_JOB in *repo* $CIRCLE_PROJECT_REPONAME \n *branch* $CIRCLE_BRANCH | *pr* $CIRCLE_PULL_REQUEST | *last commit* $CIRCLE_SHA1"
+                    "text": "*Project*: $CIRCLE_PROJECT_REPONAME \n *User*: $CIRCLE_USERNAME \n *Job*: $CIRCLE_JOB in *repo* $CIRCLE_PROJECT_REPONAME \n *Branch* $CIRCLE_BRANCH \n *PR* $CIRCLE_PULL_REQUEST \n *Last Commit* $CIRCLE_SHA1"
                   },
                   "accessory": {
                     "type": "button",
@@ -188,7 +188,7 @@ jobs:
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": "Successful Pipeline! :heavy_check_mark: :checkered_flag: :tada:",
+                    "text": "Successful Pipeline! :heavy_check_mark: :checkered_flag: :video-games-star: :tada:",
                     "emoji": true
                   }
                 },
@@ -196,7 +196,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Project*: $CIRCLE_PROJECT_REPONAME \n *User*: $CIRCLE_USERNAME \n *Job*: $CIRCLE_JOB in *repo* $CIRCLE_PROJECT_REPONAME \n *branch* $CIRCLE_BRANCH | *pr* $CIRCLE_PULL_REQUEST | *last commit* $CIRCLE_SHA1"
+                    "text": "*Project*: $CIRCLE_PROJECT_REPONAME \n *User*: $CIRCLE_USERNAME \n *Job*: $CIRCLE_JOB in *repo* $CIRCLE_PROJECT_REPONAME \n *Branch* $CIRCLE_BRANCH \n *PR* $CIRCLE_PULL_REQUEST \n *Last Commit* $CIRCLE_SHA1"
                   },
                   "accessory": {
                     "type": "button",

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Project*: $CIRCLE_PROJECT_REPONAME \n *User*: CIRCLE_PROJECT_USERNAME \n *Job*: ($CIRCLE_JOB) in *repo* $CIRCLE_PROJECT_REPONAME \n *branch* $CIRCLE_BRANCH | *pr* $CIRCLE_PULL_REQUEST | *last commit* $CIRCLE_SHA1)"
+                    "text": "*Project*: $CIRCLE_PROJECT_REPONAME \n *User*: CIRCLE_PROJECT_USERNAME \n *Job*: $CIRCLE_JOB in *repo* $CIRCLE_PROJECT_REPONAME \n *branch* $CIRCLE_BRANCH | *pr* $CIRCLE_PULL_REQUEST | *last commit* $CIRCLE_SHA1"
                   },
                   "accessory": {
                     "type": "button",
@@ -196,7 +196,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Project*: $CIRCLE_PROJECT_REPONAME \n *User*: CIRCLE_PROJECT_USERNAME \n *Job*: ($CIRCLE_JOB) in *repo* $CIRCLE_PROJECT_REPONAME \n *branch* $CIRCLE_BRANCH | *pr* $CIRCLE_PULL_REQUEST | *last commit* $CIRCLE_SHA1)"
+                    "text": "*Project*: $CIRCLE_PROJECT_REPONAME \n *User*: CIRCLE_PROJECT_USERNAME \n *Job*: $CIRCLE_JOB in *repo* $CIRCLE_PROJECT_REPONAME \n *branch* $CIRCLE_BRANCH | *pr* $CIRCLE_PULL_REQUEST | *last commit* $CIRCLE_SHA1"
                   },
                   "accessory": {
                     "type": "button",

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Project*: $CIRCLE_PROJECT_REPONAME \n *User*: CIRCLE_PROJECT_USERNAME \n *Job*: $CIRCLE_JOB in *repo* $CIRCLE_PROJECT_REPONAME \n *branch* $CIRCLE_BRANCH | *pr* $CIRCLE_PULL_REQUEST | *last commit* $CIRCLE_SHA1"
+                    "text": "*Project*: $CIRCLE_PROJECT_REPONAME \n *User*: $CIRCLE_USERNAME \n *Job*: $CIRCLE_JOB in *repo* $CIRCLE_PROJECT_REPONAME \n *branch* $CIRCLE_BRANCH | *pr* $CIRCLE_PULL_REQUEST | *last commit* $CIRCLE_SHA1"
                   },
                   "accessory": {
                     "type": "button",
@@ -196,7 +196,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Project*: $CIRCLE_PROJECT_REPONAME \n *User*: CIRCLE_PROJECT_USERNAME \n *Job*: $CIRCLE_JOB in *repo* $CIRCLE_PROJECT_REPONAME \n *branch* $CIRCLE_BRANCH | *pr* $CIRCLE_PULL_REQUEST | *last commit* $CIRCLE_SHA1"
+                    "text": "*Project*: $CIRCLE_PROJECT_REPONAME \n *User*: $CIRCLE_USERNAME \n *Job*: $CIRCLE_JOB in *repo* $CIRCLE_PROJECT_REPONAME \n *branch* $CIRCLE_BRANCH | *pr* $CIRCLE_PULL_REQUEST | *last commit* $CIRCLE_SHA1"
                   },
                   "accessory": {
                     "type": "button",

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ jobs:
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": "Failed Pipeline! :negative_squared_cross_mark::rotating_light::fire::bash-fire::bangbang::video-games-doom-mad::stopp:",
+                    "text": "Failed Pipeline! :rotating_light::fire::bash-fire::bangbang::video-games-doom-mad::stopp:",
                     "emoji": true
                   }
                 },
@@ -108,7 +108,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":bangbang: *Project*: $CIRCLE_PROJECT_REPONAME \n :bangbang: *User*: $CIRCLE_USERNAME \n :bangbang: *Job*: $CIRCLE_JOB in *repo* $CIRCLE_PROJECT_REPONAME \n :bangbang: *Branch:* $CIRCLE_BRANCH \n :bangbang: *PR:* $CIRCLE_PULL_REQUEST \n :bangbang: *Last Commit:* $CIRCLE_SHA1"
+                    "text": ":negative_squared_cross_mark: *Project*: $CIRCLE_PROJECT_REPONAME \n :negative_squared_cross_mark: *User*: $CIRCLE_USERNAME \n :negative_squared_cross_mark: *Job*: $CIRCLE_JOB in *repo* $CIRCLE_PROJECT_REPONAME \n :negative_squared_cross_mark: *Branch:* $CIRCLE_BRANCH \n :negative_squared_cross_mark: *PR:* $CIRCLE_PULL_REQUEST \n :negative_squared_cross_mark: *Last Commit:* $CIRCLE_SHA1"
                   },
                   "accessory": {
                     "type": "button",
@@ -212,7 +212,7 @@ jobs:
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": "Failed Pipeline! :negative_squared_cross_mark::rotating_light::fire::bash-fire::bangbang::video-games-doom-mad::stopp:",
+                    "text": "Failed Pipeline! :rotating_light::fire::bash-fire::bangbang::video-games-doom-mad::stopp:",
                     "emoji": true
                   }
                 },
@@ -220,7 +220,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":bangbang: *Project*: $CIRCLE_PROJECT_REPONAME \n :bangbang: *User*: $CIRCLE_USERNAME \n :bangbang: *Job*: $CIRCLE_JOB in *repo* $CIRCLE_PROJECT_REPONAME \n :bangbang: *Branch:* $CIRCLE_BRANCH \n :bangbang: *PR:* $CIRCLE_PULL_REQUEST \n :bangbang: *Last Commit:* $CIRCLE_SHA1"
+                    "text": ":negative_squared_cross_mark: *Project*: $CIRCLE_PROJECT_REPONAME \n :negative_squared_cross_mark: *User*: $CIRCLE_USERNAME \n :negative_squared_cross_mark: *Job*: $CIRCLE_JOB in *repo* $CIRCLE_PROJECT_REPONAME \n :negative_squared_cross_mark: *Branch:* $CIRCLE_BRANCH \n :negative_squared_cross_mark: *PR:* $CIRCLE_PULL_REQUEST \n :negative_squared_cross_mark: *Last Commit:* $CIRCLE_SHA1"
                   },
                   "accessory": {
                     "type": "button",

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Project*: $CIRCLE_PROJECT_REPONAME \n *User*: $CIRCLE_USERNAME \n *Job*: $CIRCLE_JOB in *repo* $CIRCLE_PROJECT_REPONAME \n *Branch:* $CIRCLE_BRANCH \n *PR:* $CIRCLE_PULL_REQUEST \n *Last Commit:* $CIRCLE_SHA1"
+                    "text": ":bangbang: *Project*: $CIRCLE_PROJECT_REPONAME \n :bangbang: *User*: $CIRCLE_USERNAME \n :bangbang: *Job*: $CIRCLE_JOB in *repo* $CIRCLE_PROJECT_REPONAME \n :bangbang: *Branch:* $CIRCLE_BRANCH \n :bangbang: *PR:* $CIRCLE_PULL_REQUEST \n :bangbang: *Last Commit:* $CIRCLE_SHA1"
                   },
                   "accessory": {
                     "type": "button",
@@ -134,7 +134,7 @@ jobs:
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": "Successful Pipeline! :heavy_check_mark::checkered_flag::video-games-star::video-games-mario-luigi-dance: :tada:   :bb-leverage::heart::open-source:",
+                    "text": "Successful Pipeline! :checkered_flag: :video-games-star: :video-games-mario-luigi-dance: :tada: :binbash::bb-leverage: :heart: :open-source:",
                     "emoji": true
                   }
                 },
@@ -220,7 +220,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Project*: $CIRCLE_PROJECT_REPONAME \n *User*: $CIRCLE_USERNAME \n *Job*: $CIRCLE_JOB in *repo* $CIRCLE_PROJECT_REPONAME \n *Branch:* $CIRCLE_BRANCH \n *PR:* $CIRCLE_PULL_REQUEST \n *Last Commit:* $CIRCLE_SHA1"
+                    "text": ":bangbang: *Project*: $CIRCLE_PROJECT_REPONAME \n :bangbang: *User*: $CIRCLE_USERNAME \n :bangbang: *Job*: $CIRCLE_JOB in *repo* $CIRCLE_PROJECT_REPONAME \n :bangbang: *Branch:* $CIRCLE_BRANCH \n :bangbang: *PR:* $CIRCLE_PULL_REQUEST \n :bangbang: *Last Commit:* $CIRCLE_SHA1"
                   },
                   "accessory": {
                     "type": "button",
@@ -246,7 +246,7 @@ jobs:
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": "Successful Pipeline! :heavy_check_mark::checkered_flag::video-games-star::video-games-mario-luigi-dance: :tada:   :bb-leverage::heart::open-source:",
+                    "text": "Successful Pipeline! :checkered_flag: :video-games-star: :video-games-mario-luigi-dance: :tada: :binbash::bb-leverage: :heart: :open-source:",
                     "emoji": true
                   }
                 },

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": "Successful Pipeline! :heavy_check_mark: :checkered_flag: :video-games-star: :tada:",
+                    "text": "Successful Pipeline! :heavy_check_mark: :checkered_flag: :video-games-star: :video-games-mario-luigi-dance: :bb-leverage::heart: :open-source: :tada:",
                     "emoji": true
                   }
                 },
@@ -113,7 +113,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Project*: $CIRCLE_PROJECT_REPONAME \n *User*: $CIRCLE_USERNAME \n *Job*: $CIRCLE_JOB in *repo* $CIRCLE_PROJECT_REPONAME \n *Branch* $CIRCLE_BRANCH \n *PR* $CIRCLE_PULL_REQUEST \n *Last Commit* $CIRCLE_SHA1"
+                    "text": "*Project*: $CIRCLE_PROJECT_REPONAME \n *User*: $CIRCLE_USERNAME \n *Job*: $CIRCLE_JOB in *repo* $CIRCLE_PROJECT_REPONAME \n *Branch:* $CIRCLE_BRANCH \n *PR:* $CIRCLE_PULL_REQUEST \n *Last Commit:* $CIRCLE_SHA1"
                   },
                   "accessory": {
                     "type": "button",
@@ -188,7 +188,7 @@ jobs:
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": "Successful Pipeline! :heavy_check_mark: :checkered_flag: :video-games-star: :tada:",
+                    "text": "Successful Pipeline! :heavy_check_mark: :checkered_flag: :video-games-star: :video-games-mario-luigi-dance: :bb-leverage::heart: :open-source: :tada:",
                     "emoji": true
                   }
                 },
@@ -196,7 +196,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Project*: $CIRCLE_PROJECT_REPONAME \n *User*: $CIRCLE_USERNAME \n *Job*: $CIRCLE_JOB in *repo* $CIRCLE_PROJECT_REPONAME \n *Branch* $CIRCLE_BRANCH \n *PR* $CIRCLE_PULL_REQUEST \n *Last Commit* $CIRCLE_SHA1"
+                    "text": "*Project*: $CIRCLE_PROJECT_REPONAME \n *User*: $CIRCLE_USERNAME \n *Job*: $CIRCLE_JOB in *repo* $CIRCLE_PROJECT_REPONAME \n *Branch:* $CIRCLE_BRANCH \n *PR:* $CIRCLE_PULL_REQUEST \n *Last Commit:* $CIRCLE_SHA1"
                   },
                   "accessory": {
                     "type": "button",

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,38 @@ jobs:
           channel: 'tools-ci'
       - slack/notify:
           event: pass
-          template: success_tagged_deploy_1
+          #template: success_tagged_deploy_1
+          custom: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "Successful Pipeline! :heavy_check_mark: :checkered_flag: :tada:",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Project*: $CIRCLE_PROJECT_REPONAME \\n *User*: $CIRCLE_PR_USERNAME \\n *Job*: ($CIRCLE_JOB) in *repo* $CIRCLE_PROJECT_REPONAME ($CIRCLE_BRANCH | $CIRCLE_PULL_REQUEST | $CIRCLE_SHA1)"
+                  },
+                  "accessory": {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": ":arrow_forward: View Job",
+                      "emoji": true
+                    },
+                    "value": "click_me_123",
+                    "url": "$CIRCLE_BUILD_URL",
+                    "action_id": "button-action"
+                  }
+                }
+              ]
+            }
           channel: 'tools-ci'
 
   #
@@ -165,7 +196,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Project*: $CIRCLE_PROJECT_REPONAME \\n*User*: $CIRCLE_PR_USERNAME \\n*Workflow*: ($CIRCLE_JOB) in $CIRCLE_PR_REPONAME ($CIRCLE_BRANCH | $CIRCLE_PULL_REQUEST | $CIRCLE_SHA1)"
+                    "text": "*Project*: $CIRCLE_PROJECT_REPONAME \\n *User*: $CIRCLE_PR_USERNAME \\n *Job*: ($CIRCLE_JOB) in *repo* $CIRCLE_PROJECT_REPONAME ($CIRCLE_BRANCH | $CIRCLE_PULL_REQUEST | $CIRCLE_SHA1)"
                   },
                   "accessory": {
                     "type": "button",

--- a/modules/delegated-admin/main.tf
+++ b/modules/delegated-admin/main.tf
@@ -4,5 +4,5 @@ resource "aws_guardduty_detector" "this" {
 }
 
 resource "aws_guardduty_organization_admin_account" "this" {
-                      admin_account_id = var.guardduty_delegated_admin_account_id
+  admin_account_id = var.guardduty_delegated_admin_account_id
 }

--- a/modules/delegated-admin/main.tf
+++ b/modules/delegated-admin/main.tf
@@ -4,5 +4,5 @@ resource "aws_guardduty_detector" "this" {
 }
 
 resource "aws_guardduty_organization_admin_account" "this" {
-  admin_account_id = var.guardduty_delegated_admin_account_id
+                      admin_account_id = var.guardduty_delegated_admin_account_id
 }


### PR DESCRIPTION
## What?
Improving CircleCI Slack notifications

### Commits on Nov 14, 2020
- @exequielrafaela - BBL-440 | updating slack ci notif template - efb767c
- @exequielrafaela - BBL-440 | improving slack notif - fe4c467
- @exequielrafaela - BBL-440 | circleci slack notif sintaxt improved - 3be367c
- @exequielrafaela - BBL-440 | fixing username var at circleci slack notif - 62da396
- @exequielrafaela - BBL-440 | improving circle slack notif stintaxt - 0d15a79
- @exequielrafaela - BBL-440 | adding emojis to slack notif :) - 01f2a1a
- @exequielrafaela - BBL-440 | updating both pass and fail slack notif - 3e0d09e
- @exequielrafaela - BBL-440 | slack notif in place - e51b3bd
- @exequielrafaela - BBL-440 | forcing job to fail to check slack notif - 7527365
- @exequielrafaela - BBL-440 | improving failed notif - 783050a
- @exequielrafaela - BBL-440 | rolling back sintaxt to get tests passing - 2cbcfe6

## Why?
- https://trello.com/c/jaQRJ7nl/447-bbl-444-ci-update-circle-ci-slack-notif-w-new-orb