### PR TITLE
Feature/adding guarduty s3 protection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,12 +41,12 @@ jobs:
             terraform --version
             #
             # Install terraform-docs
-            sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
-            curl -Lo ./terraform-docs https://github.com/terraform-docs/terraform-docs/releases/download/v0.15.0/terraform-docs-v0.15.0-$(uname | tr '[:upper:]' '[:lower:]')-amd64
-            chmod +x ./terraform-docs
+            curl -sSLo ./terraform-docs.tar.gz https://terraform-docs.io/dl/v0.16.0/terraform-docs-v0.16.0-$(uname)-amd64.tar.gz
+            tar -xzf terraform-docs.tar.gz
+            chmod +x terraform-docs
             sudo mv ./terraform-docs /usr/local/bin/terraform-docs
             terraform-docs --version
-
+            
       - run:
           name: test-terraform-format-and-docs-delegated-admin-mod
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,7 @@ jobs:
             curl -Lo ./terraform-docs https://github.com/terraform-docs/terraform-docs/releases/download/v0.15.0/terraform-docs-v0.15.0-$(uname | tr '[:upper:]' '[:lower:]')-amd64
             chmod +x ./terraform-docs
             sudo mv ./terraform-docs /usr/local/bin/terraform-docs
+            terraform-docs --version
 
       - run:
           name: test-terraform-format-and-docs-delegated-admin-mod

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
             #
             # Install terraform-docs
             sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
-            curl -Lo ./terraform-docs https://github.com/terraform-docs/terraform-docs/releases/download/v0.15.0/terraform-docs-v0.10.1-$(uname | tr '[:upper:]' '[:lower:]')-amd64
+            curl -Lo ./terraform-docs https://github.com/terraform-docs/terraform-docs/releases/download/v0.15.0/terraform-docs-v0.15.0-$(uname | tr '[:upper:]' '[:lower:]')-amd64
             chmod +x ./terraform-docs
             sudo mv ./terraform-docs /usr/local/bin/terraform-docs
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
             chmod +x terraform-docs
             sudo mv ./terraform-docs /usr/local/bin/terraform-docs
             terraform-docs --version
-            
+
       - run:
           name: test-terraform-format-and-docs-delegated-admin-mod
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
             #
             # Install terraform-docs
             sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
-            curl -Lo ./terraform-docs https://github.com/terraform-docs/terraform-docs/releases/download/v0.10.1/terraform-docs-v0.10.1-$(uname | tr '[:upper:]' '[:lower:]')-amd64
+            curl -Lo ./terraform-docs https://github.com/terraform-docs/terraform-docs/releases/download/v0.15.0/terraform-docs-v0.10.1-$(uname | tr '[:upper:]' '[:lower:]')-amd64
             chmod +x ./terraform-docs
             sudo mv ./terraform-docs /usr/local/bin/terraform-docs
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,8 @@ jobs:
   # Automated Tests
   #
   test-static-code-and-linting:
-    machine:
-      image: ubuntu-1604:202007-01 # Ubuntu 16.04, Docker v19.03.12, Docker Compose v1.26.1
+    machine: # https://circleci.com/docs/2.0/configuration-reference/#available-machine-images
+      image: ubuntu-2004:202107-01 # Ubuntu 16.04, Docker v19.03.12, Docker Compose v1.26.1
 
       # This job has been blocked because Docker Layer Caching is not available on your plan.
       # Should upgrade if necessary.
@@ -30,12 +30,13 @@ jobs:
           command: |
             #
             # Install pre-commit
-            pip install pre-commit
+            sudo -H pip3 install pre-commit
             #
             # Install terraform
-            sudo apt-get install unzip
-            wget https://releases.hashicorp.com/terraform/${TERRAFORM_VER}/terraform_${TERRAFORM_VER}_linux_amd64.zip
-            unzip terraform_${TERRAFORM_VER}_linux_amd64.zip
+            sudo apt-get install unzip curl
+            curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+            wget https://releases.hashicorp.com/terraform/${TERRAFORM_VER_REF_ARCH}/terraform_${TERRAFORM_VER_REF_ARCH}_linux_amd64.zip
+            unzip terraform_${TERRAFORM_VER_REF_ARCH}_linux_amd64.zip
             sudo mv terraform /usr/local/bin/
             terraform --version
             #
@@ -57,7 +58,7 @@ jobs:
 
       - run:
           name: Install awscli
-          command: sudo -H pip install awscli
+          command: sudo -H pip3 install awscli
 
       - run:
           name: Configure awscli
@@ -79,16 +80,6 @@ jobs:
             # moving credentials to specific project folder
             cp /home/circleci/.aws/credentials /home/circleci/.aws/bb/credentials
             cp /home/circleci/.aws/config /home/circleci/.aws/bb/config
-
-      - run:
-          name: test-terraform-linting-delegated-admin-mod
-          command: |
-            cd modules/delegated-admin && make tflint-deep
-
-      - run:
-          name: test-terraform-linting-multiaccount-setup-mod
-          command: |
-            cd modules/multiaccount-setup && make tflint-deep
 
       - slack/notify:
           event: fail
@@ -165,7 +156,7 @@ jobs:
   #
   release-version-with-changelog:
     machine:
-      image: ubuntu-1604:202007-01
+      image: ubuntu-2004:202107-01 # Ubuntu 16.04, Docker v19.03.12, Docker Compose v1.26.1
       docker_layer_caching: false
 
     environment:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
           - --markdown-linebreak-ext=md
 
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.43.0
+    rev: v1.55.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 SHELL         := /bin/bash
 MAKEFILE_PATH := ./Makefile
 MAKEFILES_DIR := ./@bin/makefiles
+MAKEFILES_VER := v0.2.0
 
 help:
 	@echo 'Available Commands:'
@@ -13,9 +14,12 @@ help:
 init-makefiles: ## initialize makefiles
 	rm -rf ${MAKEFILES_DIR}
 	mkdir -p ${MAKEFILES_DIR}
-	git clone https://github.com/binbashar/le-dev-makefiles.git ${MAKEFILES_DIR}
+	git clone https://github.com/binbashar/le-dev-makefiles.git ${MAKEFILES_DIR} -q
+	cd ${MAKEFILES_DIR} && git checkout ${MAKEFILES_VER} -q
 
 -include ${MAKEFILES_DIR}/circleci/circleci.mk
 -include ${MAKEFILES_DIR}/release-mgmt/release.mk
--include ${MAKEFILES_DIR}/terraform13/terraform13.mk
--include ${MAKEFILES_DIR}/terratest13/terratest13.mk
+-include ${MAKEFILES_DIR}/terraform1/terraform1-root-context.mk
+-include ${MAKEFILES_DIR}/terraform1/terraform1.mk
+-include ${MAKEFILES_DIR}/terratest1/terratest1.mk
+

--- a/modules/delegated-admin/README.md
+++ b/modules/delegated-admin/README.md
@@ -13,18 +13,29 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_guardduty_detector.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_detector) | resource |
+| [aws_guardduty_organization_admin_account.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_organization_admin_account) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| guardduty\_delegated\_admin\_account\_id | The account id of the account that will be GuardDuty's delegated admin. | `number` | n/a | yes |
-| guarduty\_enabled | Whether to enable GuardDuty or not. | `bool` | `true` | no |
-| guarduty\_finding\_publishing\_frequency | The frequency of findings publishing. | `string` | `"SIX_HOURS"` | no |
+| <a name="input_guardduty_delegated_admin_account_id"></a> [guardduty\_delegated\_admin\_account\_id](#input\_guardduty\_delegated\_admin\_account\_id) | The account id of the account that will be GuardDuty's delegated admin. | `number` | n/a | yes |
+| <a name="input_guarduty_enabled"></a> [guarduty\_enabled](#input\_guarduty\_enabled) | Whether to enable GuardDuty or not. | `bool` | `true` | no |
+| <a name="input_guarduty_finding_publishing_frequency"></a> [guarduty\_finding\_publishing\_frequency](#input\_guarduty\_finding\_publishing\_frequency) | The frequency of findings publishing. | `string` | `"SIX_HOURS"` | no |
+| <a name="input_guarduty_s3_protection_enabled"></a> [guarduty\_s3\_protection\_enabled](#input\_guarduty\_s3\_protection\_enabled) | Whether to enable GuardDuty S3 protection or not. | `bool` | `true` | no |
 
 ## Outputs
 
-No output.
-
+No outputs.
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/delegated-admin/main.tf
+++ b/modules/delegated-admin/main.tf
@@ -1,6 +1,12 @@
 resource "aws_guardduty_detector" "this" {
   enable                       = var.guarduty_enabled
   finding_publishing_frequency = var.guarduty_finding_publishing_frequency
+
+  datasources {
+    s3_logs {
+      enable = var.guarduty_s3_protection_enabled
+    }
+  }
 }
 
 resource "aws_guardduty_organization_admin_account" "this" {

--- a/modules/delegated-admin/makefile
+++ b/modules/delegated-admin/makefile
@@ -1,4 +1,4 @@
 MAKEFILES_DIR := ../../@bin/makefiles
 
--include ${MAKEFILES_DIR}/terratest13/terratest13.mk
--include ${MAKEFILES_DIR}/terraform13/terraform13.mk
+-include ${MAKEFILES_DIR}/terratest1/terratest1.mk
+-include ${MAKEFILES_DIR}/terraform1/terraform1.mk

--- a/modules/delegated-admin/variables.tf
+++ b/modules/delegated-admin/variables.tf
@@ -4,6 +4,12 @@ variable "guarduty_enabled" {
   description = "Whether to enable GuardDuty or not."
 }
 
+variable "guarduty_s3_protection_enabled" {
+  type        = bool
+  default     = true
+  description = "Whether to enable GuardDuty S3 protection or not."
+}
+
 variable "guarduty_finding_publishing_frequency" {
   type        = string
   default     = "SIX_HOURS"

--- a/modules/multiaccount-setup/README.md
+++ b/modules/multiaccount-setup/README.md
@@ -13,19 +13,31 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_guardduty_detector.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_detector) | resource |
+| [aws_guardduty_member.members](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_member) | resource |
+| [aws_guardduty_organization_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_organization_configuration) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| guardduty\_member\_accounts | A collection of key-pairs that hold data about member accounts such as account\_id, email and invite. | `any` | `[]` | no |
-| guardduty\_organization\_members\_auto\_enable | Whether to automatically enable GuardDuty on organization members or not. | `bool` | `true` | no |
-| guarduty\_enabled | Whether to enable GuardDuty or not. | `bool` | `true` | no |
-| guarduty\_finding\_publishing\_frequency | The frequency of findings publishing. | `string` | `"SIX_HOURS"` | no |
+| <a name="input_guardduty_member_accounts"></a> [guardduty\_member\_accounts](#input\_guardduty\_member\_accounts) | A collection of key-pairs that hold data about member accounts such as account\_id, email and invite. | `any` | `[]` | no |
+| <a name="input_guardduty_organization_members_auto_enable"></a> [guardduty\_organization\_members\_auto\_enable](#input\_guardduty\_organization\_members\_auto\_enable) | Whether to automatically enable GuardDuty on organization members or not. | `bool` | `true` | no |
+| <a name="input_guarduty_enabled"></a> [guarduty\_enabled](#input\_guarduty\_enabled) | Whether to enable GuardDuty or not. | `bool` | `true` | no |
+| <a name="input_guarduty_finding_publishing_frequency"></a> [guarduty\_finding\_publishing\_frequency](#input\_guarduty\_finding\_publishing\_frequency) | The frequency of findings publishing. | `string` | `"SIX_HOURS"` | no |
+| <a name="input_guarduty_s3_protection_enabled"></a> [guarduty\_s3\_protection\_enabled](#input\_guarduty\_s3\_protection\_enabled) | Whether to enable GuardDuty S3 protection or not. | `bool` | `true` | no |
 
 ## Outputs
 
-No output.
-
+No outputs.
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/multiaccount-setup/main.tf
+++ b/modules/multiaccount-setup/main.tf
@@ -6,6 +6,12 @@
 resource "aws_guardduty_detector" "this" {
   enable                       = var.guarduty_enabled
   finding_publishing_frequency = var.guarduty_finding_publishing_frequency
+
+  datasources {
+    s3_logs {
+      enable = var.guarduty_s3_protection_enabled
+    }
+  }
 }
 
 # Set auto_enable to true if you want GuardDuty to be enabled in all of your

--- a/modules/multiaccount-setup/makefile
+++ b/modules/multiaccount-setup/makefile
@@ -1,4 +1,4 @@
 MAKEFILES_DIR := ../../@bin/makefiles
 
--include ${MAKEFILES_DIR}/terratest13/terratest13.mk
--include ${MAKEFILES_DIR}/terraform13/terraform13.mk
+-include ${MAKEFILES_DIR}/terratest1/terratest1.mk
+-include ${MAKEFILES_DIR}/terraform1/terraform1.mk

--- a/modules/multiaccount-setup/variables.tf
+++ b/modules/multiaccount-setup/variables.tf
@@ -4,6 +4,12 @@ variable "guarduty_enabled" {
   description = "Whether to enable GuardDuty or not."
 }
 
+variable "guarduty_s3_protection_enabled" {
+  type        = bool
+  default     = true
+  description = "Whether to enable GuardDuty S3 protection or not."
+}
+
 variable "guarduty_finding_publishing_frequency" {
   type        = string
   default     = "SIX_HOURS"


### PR DESCRIPTION
## What?

### Commits on Nov 17, 2021
- Updating makefile to use new terraform 1.0.9 version lib files 
- modules/delegated-admin adding support for guarduty s3 protection 
- modules/multiaccount-setup adding support for guarduty s3 protection
  
## Why?

- Enabling S3 Protection is now supported by Terraform AWS provider. (https://github.com/terraform-providers/terraform-provider-aws/issues/14607)