### PR TITLE
Feature | Adding support to auto enable GuardDuty S3 protection at org level

### DIFF
--- a/modules/multiaccount-setup/README.md
+++ b/modules/multiaccount-setup/README.md
@@ -35,7 +35,7 @@ No modules.
 | <a name="input_guardduty_organization_members_auto_enable"></a> [guardduty\_organization\_members\_auto\_enable](#input\_guardduty\_organization\_members\_auto\_enable) | Whether to automatically enable GuardDuty on organization members or not. | `bool` | `false` | no |
 | <a name="input_guarduty_enabled"></a> [guarduty\_enabled](#input\_guarduty\_enabled) | Whether to enable GuardDuty or not. | `bool` | `true` | no |
 | <a name="input_guarduty_finding_publishing_frequency"></a> [guarduty\_finding\_publishing\_frequency](#input\_guarduty\_finding\_publishing\_frequency) | The frequency of findings publishing. | `string` | `"SIX_HOURS"` | no |
-| <a name="input_guarduty_organization_memebers_s3_protection_auto_enable"></a> [guarduty\_organization\_memebers\_s3\_protection\_auto\_enable](#input\_guarduty\_organization\_memebers\_s3\_protection\_auto\_enable) | Whether to automatically enable GuardDuty on organization members or not. | `bool` | `false` | no |
+| <a name="input_guarduty_organization_memebers_s3_protection_auto_enable"></a> [guarduty\_organization\_memebers\_s3\_protection\_auto\_enable](#input\_guarduty\_organization\_memebers\_s3\_protection\_auto\_enable) | Whether to automatically enable GuardDuty S3 protection on organization members or not. | `bool` | `false` | no |
 | <a name="input_guarduty_s3_protection_enabled"></a> [guarduty\_s3\_protection\_enabled](#input\_guarduty\_s3\_protection\_enabled) | Whether to enable GuardDuty S3 protection or not. | `bool` | `true` | no |
 
 ## Outputs

--- a/modules/multiaccount-setup/README.md
+++ b/modules/multiaccount-setup/README.md
@@ -32,9 +32,10 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_guardduty_member_accounts"></a> [guardduty\_member\_accounts](#input\_guardduty\_member\_accounts) | A collection of key-pairs that hold data about member accounts such as account\_id, email and invite. | `any` | `[]` | no |
-| <a name="input_guardduty_organization_members_auto_enable"></a> [guardduty\_organization\_members\_auto\_enable](#input\_guardduty\_organization\_members\_auto\_enable) | Whether to automatically enable GuardDuty on organization members or not. | `bool` | `true` | no |
+| <a name="input_guardduty_organization_members_auto_enable"></a> [guardduty\_organization\_members\_auto\_enable](#input\_guardduty\_organization\_members\_auto\_enable) | Whether to automatically enable GuardDuty on organization members or not. | `bool` | `false` | no |
 | <a name="input_guarduty_enabled"></a> [guarduty\_enabled](#input\_guarduty\_enabled) | Whether to enable GuardDuty or not. | `bool` | `true` | no |
 | <a name="input_guarduty_finding_publishing_frequency"></a> [guarduty\_finding\_publishing\_frequency](#input\_guarduty\_finding\_publishing\_frequency) | The frequency of findings publishing. | `string` | `"SIX_HOURS"` | no |
+| <a name="input_guarduty_organization_memebers_s3_protection_auto_enable"></a> [guarduty\_organization\_memebers\_s3\_protection\_auto\_enable](#input\_guarduty\_organization\_memebers\_s3\_protection\_auto\_enable) | Whether to automatically enable GuardDuty on organization members or not. | `bool` | `false` | no |
 | <a name="input_guarduty_s3_protection_enabled"></a> [guarduty\_s3\_protection\_enabled](#input\_guarduty\_s3\_protection\_enabled) | Whether to enable GuardDuty S3 protection or not. | `bool` | `true` | no |
 
 ## Outputs

--- a/modules/multiaccount-setup/main.tf
+++ b/modules/multiaccount-setup/main.tf
@@ -19,6 +19,12 @@ resource "aws_guardduty_detector" "this" {
 resource "aws_guardduty_organization_configuration" "this" {
   auto_enable = var.guardduty_organization_members_auto_enable
   detector_id = aws_guardduty_detector.this.id
+
+  datasources {
+    s3_logs {
+      enable = var.guarduty_organization_memebers_s3_protection_auto_enable
+    }
+  }
 }
 
 #

--- a/modules/multiaccount-setup/variables.tf
+++ b/modules/multiaccount-setup/variables.tf
@@ -18,8 +18,14 @@ variable "guarduty_finding_publishing_frequency" {
 
 variable "guardduty_organization_members_auto_enable" {
   type        = bool
-  default     = true
+  default     = false
   description = "Whether to automatically enable GuardDuty on organization members or not."
+}
+
+variable "guarduty_organization_memebers_s3_protection_auto_enable" {
+  type        = bool
+  default     = false
+  description = "Whether to automatically enable GuardDuty S3 protection on organization members or not."
 }
 
 variable "guardduty_member_accounts" {


### PR DESCRIPTION
### Commits on Nov 18, 2021
- Adding support to whether to automatically enable GuardDuty S3 protection on organization members or not. - @exequielrafaela
